### PR TITLE
CMake: Pull gobject-introspection paths from pkgconfig and always export compile_commands.json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 find_package(PkgConfig)
 pkg_check_modules(gtk4 REQUIRED IMPORTED_TARGET gtk4>=4.11.3)
 pkg_check_modules(libadwaita REQUIRED IMPORTED_TARGET libadwaita-1>=1.4)
+pkg_check_modules(gobject-introspection-1.0 REQUIRED IMPORTED_TARGET gobject-introspection-1.0>=1.77)
 
 find_program(GLIB_COMPILE_RESOURCES NAMES glib-compile-resources REQUIRED)
 
@@ -50,9 +51,10 @@ include_directories(
 )
 add_compile_definitions(AK_DONT_REPLACE_STD)
 
-foreach(prefix_dir IN LISTS CMAKE_PREFIX_PATH)
-    list(APPEND GI_TYPELIB_PATH "${prefix_dir}/lib64/girepository-1.0")
-endforeach()
+pkg_get_variable(GI_TYPELIB_PATH gobject-introspection-1.0 typelibdir)
+if (DEFINED ENV{GI_TYPELIB_PATH})
+    list(APPEND GI_TYPELIB_PATH $ENV{GI_TYPELIB_PATH})
+endif()
 list(JOIN GI_TYPELIB_PATH ":" GI_TYPELIB_PATH_ENV)
 
 set(RESOURCE_FILES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(ladybird-gtk4 C CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 find_package(PkgConfig)
 pkg_check_modules(gtk4 REQUIRED IMPORTED_TARGET gtk4>=4.11.3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,8 @@ set(WEBCONTENT_SOURCES
     "${WEBCONTENT_SOURCE_DIR}/PageHost.cpp"
     "${WEBCONTENT_SOURCE_DIR}/WebContentConsoleClient.cpp"
     "${WEBCONTENT_SOURCE_DIR}/WebDriverConnection.cpp"
+    "${SERENITY_SOURCE_DIR}/Ladybird/FontPluginLadybird.cpp"
+    "${SERENITY_SOURCE_DIR}/Ladybird/ImageCodecPluginLadybird.cpp"
     WebContentMain.cpp
 )
 add_executable(WebContent ${WEBCONTENT_SOURCES})

--- a/WebContentMain.cpp
+++ b/WebContentMain.cpp
@@ -1,14 +1,42 @@
+#include <AK/DeprecatedString.h>
+#include <Ladybird/FontPluginLadybird.h>
+#include <Ladybird/ImageCodecPluginLadybird.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/SystemServerTakeover.h>
+#include <LibFileSystem/FileSystem.h>
 #include <LibJS/Bytecode/Interpreter.h>
 #include <LibMain/Main.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
+#include <LibWeb/Loader/FrameLoader.h>
+#include <LibWeb/Platform/EventLoopPluginSerenity.h>
 #include <WebContent/ConnectionFromClient.h>
+
+DeprecatedString s_serenity_resource_root;
+
+static ErrorOr<void> platform_init() {
+    s_serenity_resource_root = TRY([]() -> ErrorOr<DeprecatedString> {
+        auto const* source_dir = getenv("SERENITY_SOURCE_DIR");
+        if (source_dir) {
+            return DeprecatedString::formatted("{}/Base", source_dir);
+        }
+        auto* home = getenv("XDG_CONFIG_HOME") ?: getenv("HOME");
+        VERIFY(home);
+        auto home_lagom = DeprecatedString::formatted("{}/.lagom", home);
+        if (FileSystem::is_directory(home_lagom))
+            return home_lagom;
+        // FIXME: Some kind of GTK resource path?
+        return Error::from_string_view("Don't know how to load resources"sv);
+    }());
+    return {};
+}
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
+    Web::Platform::EventLoopPlugin::install(*new Web::Platform::EventLoopPluginSerenity);
     Core::EventLoop event_loop;
+
+    TRY(platform_init());
 
     int webcontent_fd_passing_socket = -1;
     bool is_layout_test_mode = false;
@@ -19,6 +47,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(is_layout_test_mode, "Is layout test mode", "layout-test-mode", 0);
     args_parser.add_option(use_javascript_bytecode, "Enable JavaScript bytecode VM", "use-bytecode", 0);
     args_parser.parse(arguments);
+
+    Web::Platform::ImageCodecPlugin::install(*new Ladybird::ImageCodecPluginLadybird);
+    Web::FrameLoader::set_default_favicon_path(DeprecatedString::formatted("{}/res/icons/16x16/app-browser.png", s_serenity_resource_root));
+    Web::FrameLoader::set_error_page_url(DeprecatedString::formatted("file://{}/res/html/error.html", s_serenity_resource_root));
+    Web::Platform::FontPlugin::install(*new Ladybird::FontPluginLadybird(is_layout_test_mode));
 
     JS::Bytecode::Interpreter::set_enabled(use_javascript_bytecode);
     VERIFY(webcontent_fd_passing_socket >= 0);


### PR DESCRIPTION
This makes the blueprint compiler work on my ubuntu 22.04 install (after installing glib, libadwaita and gobject-introspection from source into /usr/local).

I tried to submit the patch on mastodon, but they would both have been more than 500 chars, even after `git format-patch HEAD~2 --no-signature --no-numbered --abbrev --minimal --no-stat -U1` :^)