### PR TITLE
meson: Add a skeleton of a meson build that can load Lagom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.flatpak-builder
+.clangd
+build/
+Build/
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 build/
 Build/
 
+subprojects/*
+!subprojects/gtk.wrap
+!subprojects/adwaita.wrap
+!subprojects/blueprint-compiler.wrap

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
-project(ladybird-gtk4 C CXX)
+project(ladybird-gtk4
+  VERSION 1.0.0
+  LANGUAGES C CXX
+)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -97,6 +100,6 @@ set(WEBCONTENT_SOURCES
 add_executable(WebContent ${WEBCONTENT_SOURCES})
 target_link_libraries(WebContent PRIVATE Lagom::Audio Lagom::Core Lagom::FileSystem Lagom::Gfx Lagom::IPC Lagom::JS Lagom::Main Lagom::Web Lagom::WebSocket)
 
-install(TARGETS LibAudio LibCore LibFileSystem LibGfx LibIPC LibJS LibWeb LibWebView LibWebSocket LibProtocol LibGUI LibMarkdown LibGemini LibHTTP LibGL LibSoftGPU LibVideo LibWasm LibXML LibIDL LibTextCodec LibCrypto LibLocale LibRegex LibSyntax LibUnicode LibCompress LibTLS LibGLSL LibGPU LibThreading)
-install(TARGETS ladybird)
-install(TARGETS WebContent DESTINATION lib)
+if (NOT CMAKE_SKIP_INSTALL_RULES)
+  include(cmake/InstallRules.cmake)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,11 +76,13 @@ set(SOURCES
     WebView.cpp
     ViewImpl.cpp
     EventLoopImplementationGLib.cpp
+    "${SERENITY_SOURCE_DIR}/Ladybird/Utilities.cpp"
+    "${SERENITY_SOURCE_DIR}/Ladybird/HelperProcess.cpp"
     $<TARGET_OBJECTS:resources>
 )
 
 add_executable(ladybird ${SOURCES})
-target_link_libraries(ladybird PRIVATE PkgConfig::gtk4 PkgConfig::libadwaita Lagom::Core Lagom::WebView Lagom::Gfx Lagom::Web Lagom::IPC)
+target_link_libraries(ladybird PRIVATE PkgConfig::gtk4 PkgConfig::libadwaita Lagom::Core Lagom::WebView Lagom::Gfx Lagom::Web Lagom::IPC Lagom::FileSystem Lagom::SQL Lagom::Protocol)
 
 include_directories(
     "${SERENITY_SOURCE_DIR}/Userland/Services"
@@ -95,6 +97,7 @@ set(WEBCONTENT_SOURCES
     "${WEBCONTENT_SOURCE_DIR}/WebDriverConnection.cpp"
     "${SERENITY_SOURCE_DIR}/Ladybird/FontPlugin.cpp"
     "${SERENITY_SOURCE_DIR}/Ladybird/ImageCodecPlugin.cpp"
+    "${SERENITY_SOURCE_DIR}/Ladybird/Utilities.cpp"
     WebContentMain.cpp
 )
 add_executable(WebContent ${WEBCONTENT_SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.23)
 project(ladybird-gtk4
   VERSION 1.0.0
   LANGUAGES C CXX
@@ -17,22 +17,10 @@ find_program(GLIB_COMPILE_RESOURCES NAMES glib-compile-resources REQUIRED)
 
 find_program(BLUEPRINT_COMPILER NAMES blueprint-compiler REQUIRED)
 
-set(LAGOM_SOURCE_DIR "${SERENITY_SOURCE_DIR}/Meta/Lagom")
-set(LAGOM_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/Lagom")
+find_package(Threads REQUIRED)
+find_package(Lagom CONFIG REQUIRED)
+find_package(ladybird CONFIG REQUIRED)
 
-include("${SERENITY_SOURCE_DIR}/Meta/CMake/lagom_compile_options.cmake")
-
-set(BUILD_LAGOM ON CACHE INTERNAL "")
-set(ENABLE_LAGOM_LIBWEB ON CACHE INTERNAL "")
-# We set EXCLUDE_FROM_ALL to make sure that only required Lagom libraries are built
-add_subdirectory("${LAGOM_SOURCE_DIR}" "${LAGOM_BINARY_DIR}" EXCLUDE_FROM_ALL)
-# FIXME: Why doesn't Lagom do this?
-include_directories(
-    "${SERENITY_SOURCE_DIR}"
-    "${SERENITY_SOURCE_DIR}/Userland/Libraries"
-    "${LAGOM_BINARY_DIR}"
-    "${LAGOM_BINARY_DIR}/Userland/Libraries"
-)
 add_compile_definitions(AK_DONT_REPLACE_STD)
 
 set(RESOURCE_FILES)
@@ -76,32 +64,11 @@ set(SOURCES
     WebView.cpp
     ViewImpl.cpp
     EventLoopImplementationGLib.cpp
-    "${SERENITY_SOURCE_DIR}/Ladybird/Utilities.cpp"
-    "${SERENITY_SOURCE_DIR}/Ladybird/HelperProcess.cpp"
     $<TARGET_OBJECTS:resources>
 )
 
 add_executable(ladybird ${SOURCES})
-target_link_libraries(ladybird PRIVATE PkgConfig::gtk4 PkgConfig::libadwaita Lagom::Core Lagom::WebView Lagom::Gfx Lagom::Web Lagom::IPC Lagom::FileSystem Lagom::SQL Lagom::Protocol)
-
-include_directories(
-    "${SERENITY_SOURCE_DIR}/Userland/Services"
-)
-
-set(WEBCONTENT_SOURCE_DIR "${SERENITY_SOURCE_DIR}/Userland/Services/WebContent")
-set(WEBCONTENT_SOURCES
-    "${WEBCONTENT_SOURCE_DIR}/ConnectionFromClient.cpp"
-    "${WEBCONTENT_SOURCE_DIR}/ConsoleGlobalEnvironmentExtensions.cpp"
-    "${WEBCONTENT_SOURCE_DIR}/PageHost.cpp"
-    "${WEBCONTENT_SOURCE_DIR}/WebContentConsoleClient.cpp"
-    "${WEBCONTENT_SOURCE_DIR}/WebDriverConnection.cpp"
-    "${SERENITY_SOURCE_DIR}/Ladybird/FontPlugin.cpp"
-    "${SERENITY_SOURCE_DIR}/Ladybird/ImageCodecPlugin.cpp"
-    "${SERENITY_SOURCE_DIR}/Ladybird/Utilities.cpp"
-    WebContentMain.cpp
-)
-add_executable(WebContent ${WEBCONTENT_SOURCES})
-target_link_libraries(WebContent PRIVATE Lagom::Audio Lagom::Core Lagom::FileSystem Lagom::Gfx Lagom::IPC Lagom::JS Lagom::Main Lagom::Web Lagom::WebSocket)
+target_link_libraries(ladybird PRIVATE PkgConfig::gtk4 PkgConfig::libadwaita ladybird::ladybird Lagom::Core Lagom::WebView Lagom::Gfx Lagom::Web Lagom::IPC Lagom::FileSystem Lagom::SQL Lagom::Protocol)
 
 if (NOT CMAKE_SKIP_INSTALL_RULES)
   include(cmake/InstallRules.cmake)

--- a/EventLoopImplementationGLib.cpp
+++ b/EventLoopImplementationGLib.cpp
@@ -144,10 +144,10 @@ void EventLoopManagerGLib::unregister_notifier(Core::Notifier& notifier)
     g_source_unref(source);
 }
 
-int EventLoopManagerGLib::register_timer(Core::Object& object, int milliseconds, bool should_reload, Core::TimerShouldFireWhenNotVisible should_fire_when_not_visible)
+int EventLoopManagerGLib::register_timer(Core::EventReceiver& object, int milliseconds, bool should_reload, Core::TimerShouldFireWhenNotVisible should_fire_when_not_visible)
 {
     struct Closure {
-        Core::Object* object;
+        Core::EventReceiver* object;
         int timer_id;
         bool should_reload : 1;
         Core::TimerShouldFireWhenNotVisible should_fire_when_not_visible : 1;
@@ -195,7 +195,7 @@ void EventLoopImplementationGLib::wake()
     g_main_context_wakeup(m_context);
 }
 
-void EventLoopImplementationGLib::post_event(Core::Object& receiver, NonnullOwnPtr<Core::Event>&& event)
+void EventLoopImplementationGLib::post_event(Core::EventReceiver& receiver, NonnullOwnPtr<Core::Event>&& event)
 {
     Core::ThreadEventQueue::current().post_event(receiver, move(event));
     if (m_context != g_main_context_get_thread_default())

--- a/EventLoopImplementationGLib.h
+++ b/EventLoopImplementationGLib.h
@@ -9,7 +9,7 @@ public:
     virtual ~EventLoopManagerGLib() override;
     virtual NonnullOwnPtr<Core::EventLoopImplementation> make_implementation() override;
 
-    virtual int register_timer(Core::Object&, int milliseconds, bool should_reload, Core::TimerShouldFireWhenNotVisible) override;
+    virtual int register_timer(Core::EventReceiver&, int milliseconds, bool should_reload, Core::TimerShouldFireWhenNotVisible) override;
     virtual bool unregister_timer(int timer_id) override;
 
     virtual void register_notifier(Core::Notifier&) override;
@@ -40,7 +40,7 @@ public:
     virtual size_t pump(PumpMode) override;
     virtual void quit(int) override;
     virtual void wake() override;
-    virtual void post_event(Core::Object& receiver, NonnullOwnPtr<Core::Event>&&) override;
+    virtual void post_event(Core::EventReceiver& receiver, NonnullOwnPtr<Core::Event>&&) override;
 
     virtual void unquit() override;
     virtual bool was_exit_requested() const override { return m_should_quit; }

--- a/README.md
+++ b/README.md
@@ -9,3 +9,51 @@ This is a project by us, for us, based on the things we like. If you like some o
 ## License
 
 This project is licensed under a 2-clause BSD license.
+
+## Building
+
+The easiest way to build is to use `flatpak-builder` to create a flatpak dev environment.
+
+
+### Setup: Install flatpak and dependencies
+
+
+On a Debian-based system like Ubuntu, the flatpak installation steps will look like below:
+
+```sh
+# Install flatpak if it's not already
+sudo apt install flatpak flatpak-builder
+```
+
+You will likely need to re-log your user session after installing flatpak to setup the environment variables properly.
+To verify that ``XDG_DATA_DIRS`` is setup properly, run ``env | grep XDG``. Something similar to the output below should be present.
+
+```
+XDG_DATA_DIRS=$HOME/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:<os-defaults>
+```
+
+### Setup: Install GNOME development flatpak packages
+
+Once flatpak is installed on your system, install the GNOME Platform and Sdk packages from the gnome-nightly repository.
+The project requires unreleased libadwaita-1 features.
+
+```sh
+# Make sure that the gnome-nightly repositories are in your user install directory
+flatpak remote-add --user --if-not-exists gnome-nightly https://nightly.gnome.org/gnome-nightly.flatpakrepo
+
+# Install the GNOME SDK
+flatpak install --user org.gnome.Platform//master org.gnome.Sdk//master
+```
+
+### Build: Build the application package
+
+```sh
+# Build and install the application to your local flatpak install
+flatpak-builder --user --install --force-clean --ccache build org.serenityos.Ladybird-gtk4.json 
+
+# Run the app
+flatpak run --user org.serenityos.Ladybird-gtk4
+```
+
+If you are only modifying the ladybird-gtk4 files, then adding the `--keep-build-dirs` flag will help
+reduce churn for the serenity components. The `--ccache` flag is essentially mandatory to reduce incremental build times.

--- a/ViewImpl.cpp
+++ b/ViewImpl.cpp
@@ -118,7 +118,7 @@ void LadybirdViewImpl::create_client(WebView::EnableCallgrindProfiling enable_ca
     (void)enable_callgrind_profiling;
     // auto candidate_web_content_paths = get_paths_for_helper_process("WebContent"sv).release_value_but_fixme_should_propagate_errors();
     Vector<String> candidate_web_content_paths;
-    candidate_web_content_paths.append("./WebContent"_string.release_value_but_fixme_should_propagate_errors());
+    candidate_web_content_paths.append("./WebContent"_string);
     auto new_client = launch_web_content_process(*this,
         candidate_web_content_paths,
         enable_callgrind_profiling)

--- a/ViewImpl.cpp
+++ b/ViewImpl.cpp
@@ -1,6 +1,8 @@
 #include "ViewImpl.h"
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibWeb/Crypto/Crypto.h>
+#include <Ladybird/Utilities.h>
+#include <Ladybird/HelperProcess.h>
 #include <adwaita.h>
 
 LadybirdViewImpl::LadybirdViewImpl(LadybirdWebView* widget)
@@ -43,85 +45,15 @@ ErrorOr<NonnullOwnPtr<LadybirdViewImpl>> LadybirdViewImpl::create(LadybirdWebVie
     return impl;
 }
 
-static ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(LadybirdViewImpl& view_impl,
-    ReadonlySpan<String> candidate_web_content_paths,
-    WebView::EnableCallgrindProfiling enable_callgrind_profiling)
-{
-    int socket_fds[2] {};
-    TRY(Core::System::socketpair(AF_LOCAL, SOCK_STREAM, 0, socket_fds));
-
-    int ui_fd = socket_fds[0];
-    int wc_fd = socket_fds[1];
-
-    int fd_passing_socket_fds[2] {};
-    TRY(Core::System::socketpair(AF_LOCAL, SOCK_STREAM, 0, fd_passing_socket_fds));
-
-    int ui_fd_passing_fd = fd_passing_socket_fds[0];
-    int wc_fd_passing_fd = fd_passing_socket_fds[1];
-
-    if (auto child_pid = TRY(Core::System::fork()); child_pid == 0) {
-        TRY(Core::System::close(ui_fd_passing_fd));
-        TRY(Core::System::close(ui_fd));
-
-        auto takeover_string = TRY(String::formatted("WebContent:{}", wc_fd));
-        TRY(Core::System::setenv("SOCKET_TAKEOVER"sv, takeover_string, true));
-
-        auto webcontent_fd_passing_socket_string = TRY(String::number(wc_fd_passing_fd));
-
-        ErrorOr<void> result;
-        for (auto const& path : candidate_web_content_paths) {
-            constexpr auto callgrind_prefix_length = 3;
-
-            if (Core::System::access(path, X_OK).is_error())
-                continue;
-            auto arguments = Vector {
-                "valgrind"sv,
-                "--tool=callgrind"sv,
-                "--instr-atstart=no"sv,
-                path.bytes_as_string_view(),
-                "--webcontent-fd-passing-socket"sv,
-                webcontent_fd_passing_socket_string
-            };
-            if (enable_callgrind_profiling == WebView::EnableCallgrindProfiling::No)
-                arguments.remove(0, callgrind_prefix_length);
-
-            result = Core::System::exec(arguments[0], arguments.span(), Core::System::SearchInPath::Yes);
-            if (!result.is_error())
-                break;
-        }
-
-        if (result.is_error())
-            warnln("Could not launch any of {}: {}", candidate_web_content_paths, result.error());
-        VERIFY_NOT_REACHED();
-    }
-    TRY(Core::System::close(wc_fd_passing_fd));
-    TRY(Core::System::close(wc_fd));
-
-    auto socket = TRY(Core::LocalSocket::adopt_fd(ui_fd));
-    TRY(socket->set_blocking(true));
-
-    auto new_client = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) WebView::WebContentClient(move(socket), view_impl)));
-    new_client->set_fd_passing_socket(TRY(Core::LocalSocket::adopt_fd(ui_fd_passing_fd)));
-
-    if (enable_callgrind_profiling == WebView::EnableCallgrindProfiling::Yes) {
-        dbgln();
-        dbgln("\033[1;45mLaunched WebContent process under callgrind!\033[0m");
-        dbgln("\033[100mRun `\033[4mcallgrind_control -i on\033[24m` to start instrumentation and `\033[4mcallgrind_control -i off\033[24m` stop it again.\033[0m");
-        dbgln();
-    }
-
-    return new_client;
-}
-
 void LadybirdViewImpl::create_client(WebView::EnableCallgrindProfiling enable_callgrind_profiling)
 {
-    (void)enable_callgrind_profiling;
-    // auto candidate_web_content_paths = get_paths_for_helper_process("WebContent"sv).release_value_but_fixme_should_propagate_errors();
-    Vector<String> candidate_web_content_paths;
-    candidate_web_content_paths.append("./WebContent"_string);
+    auto candidate_web_content_paths = MUST(get_paths_for_helper_process("WebContent"sv));
     auto new_client = launch_web_content_process(*this,
         candidate_web_content_paths,
-        enable_callgrind_profiling)
+        enable_callgrind_profiling,
+        WebView::IsLayoutTestMode::No,
+        WebView::UseJavaScriptBytecode::Yes,
+        Ladybird::UseLagomNetworking::Yes)
                           .release_value_but_fixme_should_propagate_errors();
 
     m_client_state.client = new_client;

--- a/WebContentMain.cpp
+++ b/WebContentMain.cpp
@@ -1,6 +1,7 @@
 #include <AK/DeprecatedString.h>
 #include <Ladybird/FontPlugin.h>
 #include <Ladybird/ImageCodecPlugin.h>
+#include <Ladybird/Utilities.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/SystemServerTakeover.h>
@@ -12,41 +13,23 @@
 #include <LibWeb/Platform/EventLoopPluginSerenity.h>
 #include <WebContent/ConnectionFromClient.h>
 
-DeprecatedString s_serenity_resource_root;
-
-static ErrorOr<void> platform_init()
-{
-    s_serenity_resource_root = TRY([]() -> ErrorOr<DeprecatedString> {
-        auto const* source_dir = getenv("SERENITY_SOURCE_DIR");
-        if (source_dir) {
-            return DeprecatedString::formatted("{}/Base", source_dir);
-        }
-        auto* home = getenv("XDG_CONFIG_HOME") ?: getenv("HOME");
-        VERIFY(home);
-        auto home_lagom = DeprecatedString::formatted("{}/.lagom", home);
-        if (FileSystem::is_directory(home_lagom))
-            return home_lagom;
-        // FIXME: Some kind of GTK resource path?
-        return Error::from_string_view("Don't know how to load resources"sv);
-    }());
-    return {};
-}
-
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     Web::Platform::EventLoopPlugin::install(*new Web::Platform::EventLoopPluginSerenity);
     Core::EventLoop event_loop;
 
-    TRY(platform_init());
+    platform_init();
 
     int webcontent_fd_passing_socket = -1;
     bool is_layout_test_mode = false;
     bool use_javascript_bytecode = false;
+    bool use_lagom_networking = false;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(webcontent_fd_passing_socket, "File descriptor", "webcontent-fd-passing-socket", 'c', "fd");
     args_parser.add_option(is_layout_test_mode, "Is layout test mode", "layout-test-mode", 0);
     args_parser.add_option(use_javascript_bytecode, "Enable JavaScript bytecode VM", "use-bytecode", 0);
+    args_parser.add_option(use_lagom_networking, "Enable Lagom servers for networking", "use-lagom-networking", 0);
     args_parser.parse(arguments);
 
     Web::Platform::ImageCodecPlugin::install(*new Ladybird::ImageCodecPlugin);

--- a/cmake/InstallRules.cmake
+++ b/cmake/InstallRules.cmake
@@ -1,0 +1,75 @@
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
+set(package ladybird)
+
+install(TARGETS LibAudio LibCore LibFileSystem LibGfx LibIPC LibJS LibWeb LibWebView LibWebSocket LibProtocol LibGUI LibMarkdown LibGemini LibHTTP LibGL LibSoftGPU LibVideo LibWasm LibXML LibIDL LibTextCodec LibCrypto LibLocale LibRegex LibSyntax LibUnicode LibCompress LibTLS LibGLSL LibGPU LibThreading
+  EXPORT ladybirdTargets
+  LIBRARY
+    COMPONENT ladybird_Runtime
+    NAMELINK_COMPONENT ladybird_Development
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(TARGETS ladybird WebContent
+  EXPORT ladybirdTargets
+  RUNTIME
+    COMPONENT ladybird_Runtime
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY
+    COMPONENT ladybird_Runtime
+    NAMELINK_COMPONENT ladybird_Development
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+write_basic_package_version_file(
+    "${package}ConfigVersion.cmake"
+    COMPATIBILITY SameMajorVersion
+)
+
+# Allow package maintainers to freely override the path for the configs
+set(
+  ladybird_INSTALL_CMAKEDIR "${CMAKE_INSTALL_DATADIR}/${package}"
+  CACHE PATH "CMake package config location relative to the install prefix"
+)
+mark_as_advanced(ladybird_INSTALL_CMAKEDIR)
+
+install(
+  FILES cmake/LadybirdInstallConfig.cmake
+  DESTINATION "${ladybird_INSTALL_CMAKEDIR}"
+  RENAME "${package}Config.cmake"
+  COMPONENT ladybird_Development
+)
+
+install(
+  FILES "${PROJECT_BINARY_DIR}/${package}ConfigVersion.cmake"
+  DESTINATION "${ladybird_INSTALL_CMAKEDIR}"
+  COMPONENT ladybird_Development
+)
+
+install(
+  EXPORT ladybirdTargets
+  NAMESPACE ladybird::
+  DESTINATION "${ladybird_INSTALL_CMAKEDIR}"
+  COMPONENT ladybird_Development
+)
+
+install(DIRECTORY
+    "${SERENITY_SOURCE_DIR}/Base/res/html"
+    "${SERENITY_SOURCE_DIR}/Base/res/fonts"
+    "${SERENITY_SOURCE_DIR}/Base/res/icons"
+    "${SERENITY_SOURCE_DIR}/Base/res/themes"
+    "${SERENITY_SOURCE_DIR}/Base/res/color-palettes"
+    "${SERENITY_SOURCE_DIR}/Base/res/cursor-themes"
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/res"
+  USE_SOURCE_PERMISSIONS MESSAGE_NEVER
+  COMPONENT ladybird_Runtime
+)
+
+install(FILES
+    "${SERENITY_SOURCE_DIR}/Base/home/anon/.config/BrowserAutoplayAllowlist.txt"
+    "${SERENITY_SOURCE_DIR}/Base/home/anon/.config/BrowserContentFilters.txt"
+    "${Lagom_BINARY_DIR}/cacert.pem"
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/res/ladybird"
+  COMPONENT ladybird_Runtime
+)

--- a/cmake/InstallRules.cmake
+++ b/cmake/InstallRules.cmake
@@ -1,17 +1,9 @@
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 
-set(package ladybird)
+set(package ladybird-gtk4)
 
-install(TARGETS LibAudio LibCore LibFileSystem LibGfx LibIPC LibJS LibWeb LibWebView LibWebSocket LibProtocol LibGUI LibMarkdown LibGemini LibHTTP LibGL LibSoftGPU LibVideo LibWasm LibXML LibIDL LibTextCodec LibCrypto LibLocale LibRegex LibSyntax LibUnicode LibCompress LibTLS LibGLSL LibGPU LibThreading LibSQL
-  EXPORT ladybirdTargets
-  LIBRARY
-    COMPONENT ladybird_Runtime
-    NAMELINK_COMPONENT ladybird_Development
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)
-
-install(TARGETS ladybird WebContent
+install(TARGETS ladybird
   EXPORT ladybirdTargets
   RUNTIME
     COMPONENT ladybird_Runtime
@@ -49,27 +41,7 @@ install(
 
 install(
   EXPORT ladybirdTargets
-  NAMESPACE ladybird::
+  NAMESPACE ladybird-gtk4::
   DESTINATION "${ladybird_INSTALL_CMAKEDIR}"
   COMPONENT ladybird_Development
-)
-
-install(DIRECTORY
-    "${SERENITY_SOURCE_DIR}/Base/res/html"
-    "${SERENITY_SOURCE_DIR}/Base/res/fonts"
-    "${SERENITY_SOURCE_DIR}/Base/res/icons"
-    "${SERENITY_SOURCE_DIR}/Base/res/themes"
-    "${SERENITY_SOURCE_DIR}/Base/res/color-palettes"
-    "${SERENITY_SOURCE_DIR}/Base/res/cursor-themes"
-  DESTINATION "${CMAKE_INSTALL_DATADIR}/res"
-  USE_SOURCE_PERMISSIONS MESSAGE_NEVER
-  COMPONENT ladybird_Runtime
-)
-
-install(FILES
-    "${SERENITY_SOURCE_DIR}/Base/home/anon/.config/BrowserAutoplayAllowlist.txt"
-    "${SERENITY_SOURCE_DIR}/Base/home/anon/.config/BrowserContentFilters.txt"
-    "${Lagom_BINARY_DIR}/cacert.pem"
-  DESTINATION "${CMAKE_INSTALL_DATADIR}/res/ladybird"
-  COMPONENT ladybird_Runtime
 )

--- a/cmake/InstallRules.cmake
+++ b/cmake/InstallRules.cmake
@@ -3,7 +3,7 @@ include(GNUInstallDirs)
 
 set(package ladybird)
 
-install(TARGETS LibAudio LibCore LibFileSystem LibGfx LibIPC LibJS LibWeb LibWebView LibWebSocket LibProtocol LibGUI LibMarkdown LibGemini LibHTTP LibGL LibSoftGPU LibVideo LibWasm LibXML LibIDL LibTextCodec LibCrypto LibLocale LibRegex LibSyntax LibUnicode LibCompress LibTLS LibGLSL LibGPU LibThreading
+install(TARGETS LibAudio LibCore LibFileSystem LibGfx LibIPC LibJS LibWeb LibWebView LibWebSocket LibProtocol LibGUI LibMarkdown LibGemini LibHTTP LibGL LibSoftGPU LibVideo LibWasm LibXML LibIDL LibTextCodec LibCrypto LibLocale LibRegex LibSyntax LibUnicode LibCompress LibTLS LibGLSL LibGPU LibThreading LibSQL
   EXPORT ladybirdTargets
   LIBRARY
     COMPONENT ladybird_Runtime

--- a/cmake/LadybirdInstallConfig.cmake
+++ b/cmake/LadybirdInstallConfig.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/ladybirdTargets.cmake")

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,112 @@
+project(
+    'ladybird-gtk',
+    'c',
+    'cpp',
+    license: 'BSD-2-Clause',
+    version: '1.0-dev',
+    default_options: [
+        'warning_level=1',
+        'buildtype=debugoptimized',
+        'cpp_std=c++20',
+    ],
+)
+
+gnome = import('gnome')
+
+gtk_min_version = '>= 4.11.3'
+libadwaita_min_version = '>=1.4'
+
+gtk_dep = dependency(
+    'gtk4',
+    version: gtk_min_version,
+    default_options: ['build-tests=false', 'build-testsuite=false'],
+)
+libadwaita_dep = dependency(
+    'libadwaita-1',
+    version: libadwaita_min_version,
+    fallback: ['adwaita', 'libadwaita_dep'],
+)
+
+lagom_dep = dependency(
+    'Lagom',
+    method: 'cmake',
+    modules: [
+        'Lagom::Core',
+        'Lagom::FileSystem',
+        'Lagom::Gfx',
+        'Lagom::IPC',
+        'Lagom::Main',
+        'Lagom::Web',
+        'Lagom::WebView',
+        'Lagom::SQL',
+        'Lagom::Protocol',
+    ],
+)
+ladybird_dep = dependency(
+    'ladybird',
+    method: 'cmake',
+    modules: ['ladybird::ladybird'],
+)
+
+add_project_arguments(
+    [
+        '-DAK_DONT_REPLACE_STD',
+        '-Wno-literal-suffix',
+    ],
+    language: 'cpp',
+)
+
+
+libadwaita_dep_type = libadwaita_dep.type_name()
+if libadwaita_dep_type == 'pkgconfig'
+    libadwaita_typelib_path = (
+        libadwaita_dep.get_pkgconfig_variable('libdir') / 'girepository-1.0'
+    )
+else
+    # FIXME: How to get the build dir of the subproject properly?
+    libadwaita_typelib_path = (
+        meson.current_build_dir() / 'subprojects/adwaita/src'
+    )
+endif
+
+blueprints = custom_target(
+    'blueprints',
+    input: files('window.blp'),
+    env: {
+        'GI_TYPELIB_PATH': libadwaita_typelib_path,
+    },
+    output: 'window.ui',
+    command: [
+        find_program('blueprint-compiler'),
+        'batch-compile',
+        '@OUTDIR@',
+        '@CURRENT_SOURCE_DIR@',
+        '@INPUT@',
+    ],
+)
+
+resources = gnome.compile_resources(
+    'ladybird-resources',
+    'gresources.xml',
+    c_name: 'ladybird_resources',
+    source_dir: '.',
+    dependencies: [blueprints],
+)
+
+ladybird = executable(
+    'ladybird',
+    dependencies: [
+        lagom_dep,
+        gtk_dep,
+        libadwaita_dep,
+        ladybird_dep,
+        declare_dependency(sources: [resources]),
+    ],
+    sources: [
+        'main.cpp',
+        'Window.cpp',
+        'WebView.cpp',
+        'ViewImpl.cpp',
+        'EventLoopImplementationGLib.cpp',
+    ],
+)

--- a/org.serenityos.Ladybird-gtk4.json
+++ b/org.serenityos.Ladybird-gtk4.json
@@ -10,7 +10,8 @@
         "--share=network",
         "--socket=fallback-x11",
         "--socket=wayland",
-        "--socket=pulseaudio"
+        "--socket=pulseaudio",
+        "--socket=session-bus"
     ],
     "cleanup": [
         "blueprint*",

--- a/org.serenityos.Ladybird-gtk4.json
+++ b/org.serenityos.Ladybird-gtk4.json
@@ -38,8 +38,8 @@
                     "dest": "serenity"
                 },
                 {
-                    "type": "git",
-                    "url": "https://github.com/bugaevc/ladybird-gtk4.git"
+                    "type": "dir",
+                    "path": "."
                 }
             ],
             "config-opts": ["-DSERENITY_SOURCE_DIR=serenity"],

--- a/org.serenityos.Ladybird-gtk4.json
+++ b/org.serenityos.Ladybird-gtk4.json
@@ -30,23 +30,33 @@
             ]
         },
         {
-            "name": "Ladybird",
+            "name": "lagom",
             "buildsystem": "cmake-ninja",
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://github.com/SerenityOS/serenity.git",
-                    "dest": "serenity"
+                    "url": "https://github.com/ADKaster/serenity.git",
+                    "branch": "ladybird-options"
                 },
+                {
+                    "type": "patch",
+                    "path": "patches/0001-CMake-Include-Lagom-at-top-level.patch"
+                }
+            ],
+            "config-opts": [ "-DBUILD_LAGOM=ON", "-DENABLE_LAGOM_LADYBIRD=ON", "-DENABLE_QT=OFF" ],
+            "build-options": {
+                "build-args": ["--share=network"]
+            }
+        },
+        {
+            "name": "Ladybird",
+            "buildsystem": "cmake-ninja",
+            "sources": [
                 {
                     "type": "dir",
                     "path": "."
                 }
-            ],
-            "config-opts": ["-DSERENITY_SOURCE_DIR=serenity"],
-            "build-options": {
-                "build-args": ["--share=network"]
-            }
+            ]
         }
     ]
 }

--- a/patches/0001-CMake-Include-Lagom-at-top-level.patch
+++ b/patches/0001-CMake-Include-Lagom-at-top-level.patch
@@ -1,0 +1,23 @@
+From eacba1ad974c6c03d8ab3321cdae0776f9c2afa0 Mon Sep 17 00:00:00 2001
+From: Andrew Kaster <akaster@serenityos.org>
+Date: Wed, 2 Aug 2023 20:32:03 -0600
+Subject: [PATCH 1/2] CMake: Include Lagom at top level
+
+---
+ CMakeLists.txt | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e2a0f36..9f3ada6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,3 +1,6 @@
++add_subdirectory(Meta/Lagom)
++return()
++
+ cmake_minimum_required(VERSION 3.25)
+ 
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/Meta/CMake")
+-- 
+2.34.1
+

--- a/subprojects/adwaita.wrap
+++ b/subprojects/adwaita.wrap
@@ -1,0 +1,7 @@
+[wrap-git]
+url = https://gitlab.gnome.org/GNOME/libadwaita.git
+revision = main
+depth = 1
+
+[provide]
+dependency_names = libadwaita-1

--- a/subprojects/blueprint-compiler.wrap
+++ b/subprojects/blueprint-compiler.wrap
@@ -1,0 +1,8 @@
+[wrap-git]
+directory = blueprint-compiler
+url = https://gitlab.gnome.org/jwestman/blueprint-compiler.git
+revision = main
+depth = 1
+
+[provide]
+program_names = blueprint-compiler

--- a/subprojects/gtk.wrap
+++ b/subprojects/gtk.wrap
@@ -1,0 +1,7 @@
+[wrap-git]
+url = https://gitlab.gnome.org/GNOME/gtk.git
+revision = main
+depth = 1
+
+[provide]
+dependency_names = gtk4


### PR DESCRIPTION
@bugaevc As I mentioned on discord, this actually doesn't work. 

The issue with subprojects is resolved. However, now we come to the issue that meson simply cannot run our code generators.

It doesn't understand the TARGET_FILE generator expression, and so it can't properly invoke them.

This is a fundamental problem with meson cmake support, and we need to find another way to add the dependency other than as a cmake subproject. If we could convince *something* to install the Lagom/Ladybird project with `cmake --install` and then use a depdendency(type: 'cmake')` or w/e to use `find_package`, we would be in the money though. Not sure how to do that without going to the flatpak, which this was so close to removing the need for.

