### PR TITLE
Fix build after URL scheme change from DeprecatedString to String

### DIFF
--- a/RequestManagerSoup.cpp
+++ b/RequestManagerSoup.cpp
@@ -22,7 +22,7 @@ RefPtr<Web::ResourceLoaderConnectorRequest> RequestManagerSoup::start_request(
     HashMap<DeprecatedString, DeprecatedString> const& request_headers,
     ReadonlyBytes request_body, Core::ProxyData const& proxy)
 {
-    if (!url.scheme().is_one_of_ignoring_ascii_case("http"sv, "https"sv))
+    if (!url.scheme().bytes_as_string_view().is_one_of_ignoring_ascii_case("http"sv, "https"sv))
         return nullptr;
 
     auto request_or_error = RequestSoup::create(m_session, method, url, request_headers, request_body, proxy);


### PR DESCRIPTION
Adapt to c25485700a7bbdbb2eae84e036396de067b2e9fb from the main Serenity repository.