### PR TITLE
Update the GTK web view with recent LibWebView API changes

### DIFF
--- a/ViewImpl.h
+++ b/ViewImpl.h
@@ -22,25 +22,6 @@ public:
 private:
     LadybirdViewImpl(LadybirdWebView* widget);
 
-    virtual void notify_server_did_layout(Badge<WebView::WebContentClient>, Gfx::IntSize content_size) override;
-    virtual void notify_server_did_paint(Badge<WebView::WebContentClient>, i32 bitmap_id, Gfx::IntSize) override;
-    virtual void notify_server_did_invalidate_content_rect(Badge<WebView::WebContentClient>, Gfx::IntRect const&) override;
-    virtual void notify_server_did_change_selection(Badge<WebView::WebContentClient>) override;
-    virtual void notify_server_did_request_cursor_change(Badge<WebView::WebContentClient>, Gfx::StandardCursor cursor) override;
-    virtual void notify_server_did_request_scroll(Badge<WebView::WebContentClient>, i32, i32) override;
-    virtual void notify_server_did_request_scroll_to(Badge<WebView::WebContentClient>, Gfx::IntPoint) override;
-    virtual void notify_server_did_request_scroll_into_view(Badge<WebView::WebContentClient>, Gfx::IntRect const&) override;
-    virtual void notify_server_did_enter_tooltip_area(Badge<WebView::WebContentClient>, Gfx::IntPoint, DeprecatedString const&) override;
-    virtual void notify_server_did_leave_tooltip_area(Badge<WebView::WebContentClient>) override;
-    virtual void notify_server_did_request_alert(Badge<WebView::WebContentClient>, String const& message) override;
-    virtual void notify_server_did_request_confirm(Badge<WebView::WebContentClient>, String const& message) override;
-    virtual void notify_server_did_request_prompt(Badge<WebView::WebContentClient>, String const& message, String const& default_) override;
-    virtual void notify_server_did_request_set_prompt_text(Badge<WebView::WebContentClient>, String const& message) override;
-    virtual void notify_server_did_request_accept_dialog(Badge<WebView::WebContentClient>) override;
-    virtual void notify_server_did_request_dismiss_dialog(Badge<WebView::WebContentClient>) override;
-    virtual void notify_server_did_request_file(Badge<WebView::WebContentClient>, DeprecatedString const& path, i32) override;
-    virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) override;
-
     virtual void update_zoom() override;
     virtual Gfx::IntRect viewport_rect() const override;
     virtual Gfx::IntPoint to_content_position(Gfx::IntPoint widget_position) const override;
@@ -48,6 +29,7 @@ private:
 
     virtual void create_client(WebView::EnableCallgrindProfiling) override;
 
+    void update_cursor(Gfx::StandardCursor);
     void update_theme();
     Browser::CookieJar& cookie_jar();
 


### PR DESCRIPTION
There have been a handful of commits to the upstream LibWebView in an
effort to reduce the amount of work and code duplication required to
bring up a new LibWeb chrome. This patch ports the GTK chrome to align
with those changes.

@bugaevc I was only able to test this patch against the `older-dependencies` branch, but it merged cleanly into the `master` branch so it should be okay.