### PR TITLE
Replace Browser::CookieJar with WebView::CookieJar

### DIFF
--- a/Application.cpp
+++ b/Application.cpp
@@ -1,14 +1,14 @@
 #include "Application.h"
 #include "Window.h"
 #include <AK/OwnPtr.h>
-#include <Browser/CookieJar.h>
+#include <LibWebView/CookieJar.h>
 #include <glib/gi18n.h>
 
 struct _LadybirdApplication {
     AdwApplication parent_instance;
 
-    OwnPtr<Browser::CookieJar> cookie_jar;
-    OwnPtr<Browser::CookieJar> incognito_cookie_jar;
+    OwnPtr<WebView::CookieJar> cookie_jar;
+    OwnPtr<WebView::CookieJar> incognito_cookie_jar;
 };
 
 G_BEGIN_DECLS
@@ -118,26 +118,26 @@ static void ladybird_application_open(GApplication* app, GFile** files, int num_
     gtk_window_present(GTK_WINDOW(window));
 }
 
-Browser::CookieJar* ladybird_application_get_cookie_jar(LadybirdApplication* self)
+WebView::CookieJar* ladybird_application_get_cookie_jar(LadybirdApplication* self)
 {
     g_return_val_if_fail(LADYBIRD_IS_APPLICATION(self), nullptr);
 
     if (!self->cookie_jar) {
         // TODO: This should attempt creating the jar from a database.
-        auto jar = Browser::CookieJar::create();
-        self->cookie_jar = make<Browser::CookieJar>(move(jar));
+        auto jar = WebView::CookieJar::create();
+        self->cookie_jar = make<WebView::CookieJar>(move(jar));
     }
 
     return self->cookie_jar;
 }
 
-Browser::CookieJar* ladybird_application_get_incognito_cookie_jar(LadybirdApplication* self)
+WebView::CookieJar* ladybird_application_get_incognito_cookie_jar(LadybirdApplication* self)
 {
     g_return_val_if_fail(LADYBIRD_IS_APPLICATION(self), nullptr);
 
     if (!self->incognito_cookie_jar) {
-        auto jar = Browser::CookieJar::create();
-        self->incognito_cookie_jar = make<Browser::CookieJar>(move(jar));
+        auto jar = WebView::CookieJar::create();
+        self->incognito_cookie_jar = make<WebView::CookieJar>(move(jar));
     }
 
     return self->incognito_cookie_jar;
@@ -155,8 +155,8 @@ static void ladybird_application_dispose(GObject* object)
 
 static void ladybird_application_init([[maybe_unused]] LadybirdApplication* self)
 {
-    new (&self->cookie_jar) OwnPtr<Browser::CookieJar>;
-    new (&self->incognito_cookie_jar) OwnPtr<Browser::CookieJar>;
+    new (&self->cookie_jar) OwnPtr<WebView::CookieJar>;
+    new (&self->incognito_cookie_jar) OwnPtr<WebView::CookieJar>;
 
     GtkApplication* gtk_app = GTK_APPLICATION(self);
 

--- a/Application.h
+++ b/Application.h
@@ -10,11 +10,11 @@ G_DECLARE_FINAL_TYPE(LadybirdApplication, ladybird_application, LADYBIRD, APPLIC
 
 LadybirdApplication* ladybird_application_new(void);
 
-namespace Browser {
+namespace WebView {
 class CookieJar;
 }
 
-Browser::CookieJar* ladybird_application_get_cookie_jar(LadybirdApplication* self);
-Browser::CookieJar* ladybird_application_get_incognito_cookie_jar(LadybirdApplication* self);
+WebView::CookieJar* ladybird_application_get_cookie_jar(LadybirdApplication* self);
+WebView::CookieJar* ladybird_application_get_incognito_cookie_jar(LadybirdApplication* self);
 
 G_END_DECLS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,15 +96,13 @@ set(SOURCES
     EventLoopImplementationGLib.cpp
     "${SERENITY_SOURCE_DIR}/Ladybird/Utilities.cpp"
     "${SERENITY_SOURCE_DIR}/Ladybird/HelperProcess.cpp"
-    "${SERENITY_SOURCE_DIR}/Userland/Applications/Browser/CookieJar.cpp"
-    "${SERENITY_SOURCE_DIR}/Userland/Applications/Browser/Database.cpp"
     $<TARGET_OBJECTS:resources>
 )
 
 add_subdirectory(po)
 
 add_executable(ladybird ${SOURCES})
-target_link_libraries(ladybird PRIVATE PkgConfig::gtk4 PkgConfig::libadwaita Lagom::Core Lagom::WebView Lagom::Gfx Lagom::Web Lagom::IPC Lagom::FileSystem Lagom::SQL Lagom::Protocol)
+target_link_libraries(ladybird PRIVATE PkgConfig::gtk4 PkgConfig::libadwaita Lagom::Core Lagom::WebView Lagom::Gfx Lagom::Web Lagom::IPC Lagom::FileSystem Lagom::Protocol)
 
 if (libsoup_FOUND)
     target_link_libraries(ladybird PRIVATE PkgConfig::libsoup)

--- a/ViewImpl.cpp
+++ b/ViewImpl.cpp
@@ -1,10 +1,10 @@
 #include "ViewImpl.h"
 #include "BitmapPaintable.h"
-#include <Browser/CookieJar.h>
 #include <Ladybird/HelperProcess.h>
 #include <Ladybird/Utilities.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibWeb/Crypto/Crypto.h>
+#include <LibWebView/CookieJar.h>
 #include <adwaita.h>
 
 LadybirdViewImpl::LadybirdViewImpl(LadybirdWebView* widget)
@@ -108,9 +108,9 @@ ErrorOr<NonnullOwnPtr<LadybirdViewImpl>> LadybirdViewImpl::create(LadybirdWebVie
     return impl;
 }
 
-Browser::CookieJar& LadybirdViewImpl::cookie_jar()
+WebView::CookieJar& LadybirdViewImpl::cookie_jar()
 {
-    Browser::CookieJar* jar = ladybird_web_view_get_cookie_jar(m_widget);
+    WebView::CookieJar* jar = ladybird_web_view_get_cookie_jar(m_widget);
     VERIFY(jar);
     return *jar;
 }

--- a/ViewImpl.h
+++ b/ViewImpl.h
@@ -31,7 +31,7 @@ private:
 
     void update_cursor(Gfx::StandardCursor);
     void update_theme();
-    Browser::CookieJar& cookie_jar();
+    WebView::CookieJar& cookie_jar();
 
     Gfx::IntRect m_viewport_rect;
     LadybirdWebView* m_widget { nullptr };

--- a/WebView.cpp
+++ b/WebView.cpp
@@ -8,7 +8,7 @@ struct _LadybirdWebView {
     OwnPtr<LadybirdViewImpl> impl;
     LadybirdBitmapPaintable* bitmap_paintable;
     LadybirdBitmapPaintable* favicon;
-    Browser::CookieJar* cookie_jar;
+    WebView::CookieJar* cookie_jar;
     GtkScrollablePolicy hscroll_policy;
     GtkAdjustment* hadjustment;
     GtkScrollablePolicy vscroll_policy;
@@ -170,14 +170,14 @@ guint ladybird_web_view_get_zoom_percent(LadybirdWebView* self)
     return round(self->impl->zoom_level() * 100.0);
 }
 
-Browser::CookieJar* ladybird_web_view_get_cookie_jar(LadybirdWebView* self)
+WebView::CookieJar* ladybird_web_view_get_cookie_jar(LadybirdWebView* self)
 {
     g_return_val_if_fail(LADYBIRD_IS_WEB_VIEW(self), nullptr);
 
     return self->cookie_jar;
 }
 
-void ladybird_web_view_set_cookie_jar(LadybirdWebView* self, Browser::CookieJar* cookie_jar)
+void ladybird_web_view_set_cookie_jar(LadybirdWebView* self, WebView::CookieJar* cookie_jar)
 {
     g_return_if_fail(LADYBIRD_IS_WEB_VIEW(self));
 
@@ -282,7 +282,7 @@ static void ladybird_web_view_set_property(GObject* object, guint prop_id, GValu
         break;
 
     case PROP_COOKIE_JAR:
-        ladybird_web_view_set_cookie_jar(self, reinterpret_cast<Browser::CookieJar*>(g_value_get_pointer(value)));
+        ladybird_web_view_set_cookie_jar(self, reinterpret_cast<WebView::CookieJar*>(g_value_get_pointer(value)));
         break;
 
     case PROP_HOVERED_LINK:

--- a/WebView.h
+++ b/WebView.h
@@ -35,11 +35,11 @@ void ladybird_web_view_scroll_by(LadybirdWebView* self, int page_x_delta, int pa
 void ladybird_web_view_scroll_to(LadybirdWebView* self, int page_x, int page_y);
 void ladybird_web_view_scroll_into_view(LadybirdWebView* self, int page_x, int page_y, int page_width, int page_height);
 
-namespace Browser {
+namespace WebView {
 class CookieJar;
-};
+}
 
-Browser::CookieJar* ladybird_web_view_get_cookie_jar(LadybirdWebView* self);
-void ladybird_web_view_set_cookie_jar(LadybirdWebView* self, Browser::CookieJar* cookie_jar);
+WebView::CookieJar* ladybird_web_view_get_cookie_jar(LadybirdWebView* self);
+void ladybird_web_view_set_cookie_jar(LadybirdWebView* self, WebView::CookieJar* cookie_jar);
 
 G_END_DECLS

--- a/Window.cpp
+++ b/Window.cpp
@@ -59,7 +59,7 @@ static void update_favicon(LadybirdBitmapPaintable* favicon_paintable, [[maybe_u
 static AdwTabPage* open_new_tab(LadybirdWindow* self, AdwTabPage* parent)
 {
     LadybirdApplication* app = LADYBIRD_APPLICATION(gtk_window_get_application(GTK_WINDOW(self)));
-    Browser::CookieJar* cookie_jar = self->incognito
+    WebView::CookieJar* cookie_jar = self->incognito
         ? ladybird_application_get_incognito_cookie_jar(app)
         : ladybird_application_get_cookie_jar(app);
 


### PR DESCRIPTION
The CookieJar was moved from Serenity's Applications/Browser to LibWebView.

This depends on https://github.com/SerenityOS/serenity/pull/20863 being merged first.