### PR TITLE
cmake: Build ImageDecoder server, and depend on its client library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,16 @@ find_program(GLIB_COMPILE_RESOURCES NAMES glib-compile-resources REQUIRED)
 
 find_program(BLUEPRINT_COMPILER NAMES blueprint-compiler REQUIRED)
 
+get_filename_component(SERENITY_SOURCE_DIR "${SERENITY_SOURCE_DIR}" ABSOLUTE CACHE FORCE)
+
 set(LAGOM_SOURCE_DIR "${SERENITY_SOURCE_DIR}/Meta/Lagom")
 set(LAGOM_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/Lagom")
 
 include("${SERENITY_SOURCE_DIR}/Meta/CMake/lagom_compile_options.cmake")
+macro(serenity_option)
+    set(${ARGV})
+endmacro()
+include("${SERENITY_SOURCE_DIR}/Meta/CMake/lagom_options.cmake")
 
 set(BUILD_LAGOM ON CACHE INTERNAL "")
 set(ENABLE_LAGOM_LIBWEB ON CACHE INTERNAL "")
@@ -106,7 +112,7 @@ set(SOURCES
 add_subdirectory(po)
 
 add_executable(ladybird ${SOURCES})
-target_link_libraries(ladybird PRIVATE PkgConfig::gtk4 PkgConfig::libadwaita Lagom::Core Lagom::WebView Lagom::Gfx Lagom::Web Lagom::IPC Lagom::FileSystem Lagom::Protocol)
+target_link_libraries(ladybird PRIVATE PkgConfig::gtk4 PkgConfig::libadwaita Lagom::Core Lagom::WebView Lagom::Gfx Lagom::Web Lagom::IPC Lagom::FileSystem Lagom::Protocol Lagom::ImageDecoderClient)
 
 if (libsoup_FOUND)
     target_link_libraries(ladybird PRIVATE PkgConfig::libsoup)
@@ -137,10 +143,13 @@ if (libsoup_FOUND)
 endif()
 
 add_executable(WebContent ${WEBCONTENT_SOURCES})
-target_link_libraries(WebContent PRIVATE Lagom::Audio Lagom::Core Lagom::FileSystem Lagom::Gfx Lagom::IPC Lagom::JS Lagom::Main Lagom::Web Lagom::WebSocket Lagom::WebView Lagom::Protocol)
+target_link_libraries(WebContent PRIVATE Lagom::Audio Lagom::Core Lagom::FileSystem Lagom::Gfx Lagom::IPC Lagom::JS Lagom::Main Lagom::Web Lagom::WebSocket Lagom::WebView Lagom::Protocol Lagom::ImageDecoderClient)
 if (libsoup_FOUND)
     target_link_libraries(WebContent PRIVATE PkgConfig::libsoup)
 endif()
+
+add_subdirectory("${SERENITY_SOURCE_DIR}/Ladybird/ImageDecoder" "${Lagom_BINARY_DIR}/ImageDecoder")
+add_dependencies(WebContent ImageDecoder)
 
 if (NOT CMAKE_SKIP_INSTALL_RULES)
   include(cmake/InstallRules.cmake)

--- a/cmake/InstallRules.cmake
+++ b/cmake/InstallRules.cmake
@@ -1,10 +1,10 @@
 include(GNUInstallDirs)
 
-install(TARGETS LibAudio LibCore LibFileSystem LibGfx LibIPC LibJS LibWeb LibWebView LibWebSocket LibProtocol LibGUI LibMarkdown LibGemini LibHTTP LibGL LibSoftGPU LibVideo LibWasm LibXML LibIDL LibTextCodec LibCrypto LibLocale LibRegex LibSyntax LibUnicode LibCompress LibTLS LibGLSL LibGPU LibThreading LibSQL
+install(TARGETS LibAudio LibCore LibFileSystem LibGfx LibIPC LibJS LibWeb LibWebView LibWebSocket LibProtocol LibGUI LibMarkdown LibGemini LibHTTP LibGL LibSoftGPU LibVideo LibWasm LibXML LibIDL LibTextCodec LibCrypto LibLocale LibRegex LibSyntax LibUnicode LibCompress LibTLS LibGLSL LibGPU LibThreading LibSQL LibImageDecoderClient LibX86 LibJIT
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
-install(TARGETS ladybird WebContent
+install(TARGETS ladybird WebContent ImageDecoder
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 

--- a/org.serenityos.Ladybird-gtk4.json
+++ b/org.serenityos.Ladybird-gtk4.json
@@ -35,15 +35,15 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://www.unicode.org/Public/15.0.0/ucd/UCD.zip",
+                    "url": "https://www.unicode.org/Public/15.1.0/ucd/UCD.zip",
                     "dest": "Caches/UCD/",
-                    "sha256": "5fbde400f3e687d25cc9b0a8d30d7619e76cb2f4c3e85ba9df8ec1312cb6718c",
+                    "sha256": "cb1c663d053926500cd501229736045752713a066bd75802098598b7a7056177",
                     "strip-components": 0,
                     "dest-filename": "UCD.zip"
                 },
                 {
                     "type": "file",
-                    "url": "https://www.unicode.org/Public/emoji/15.0/emoji-test.txt",
+                    "url": "https://www.unicode.org/Public/emoji/15.1/emoji-test.txt",
                     "dest": "Caches/UCD/",
                     "sha256": "8445f23ac8388e096be19d0262e14fceff856ff52093f2356dc89485f1a853db"
                 },
@@ -72,7 +72,7 @@
                 {
                     "type": "shell",
                     "commands": [
-                        "echo -n 15.0.0 > Caches/UCD/version.txt",
+                        "echo -n 15.1.0 > Caches/UCD/version.txt",
                         "echo -n 43.1.0 > Caches/CLDR/version.txt",
                         "echo -n 2023c > Caches/TZDB/version.txt",
                         "echo -n 2023-05-30 > Caches/CACERT/version.txt",


### PR DESCRIPTION
- Update UCD version
- Use serenity's lagom_options to set CMAKE_RUNTIME_OUTPUT_DIRECTORY so that ImageDecoder is findable by ladybird binary in the build directory.